### PR TITLE
Allow to override CC and CXX binaries

### DIFF
--- a/Make.config
+++ b/Make.config
@@ -3,10 +3,10 @@
 
 ### The C compiler and options:
 
-CC       = gcc
-CFLAGS ?= -O2
+CC       ?= gcc
+CFLAGS   ?= -O2
 
-CXX      = g++
+CXX      ?= g++
 CXXFLAGS ?= -g -O2 -Wall -Woverloaded-virtual
 #CXXFLAGS ?= -g -ggdb -O0 -Wall -Woverloaded-virtual
 


### PR DESCRIPTION
This patch makes it possible to override the default binaries for `CC` and `CXX`.
For example on Gentoo, we don't use hardcoded `gcc` or `g++` commands, as portage sets it's path to there.